### PR TITLE
ci: 新增质量门禁（前端 lint/单测 + Rust fmt/clippy/test）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: Quality Gates
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  frontend:
+    name: Frontend (lint + unit tests)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Enable pnpm
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Unit tests
+        run: pnpm test:unit
+
+  backend:
+    name: Backend (fmt + clippy + tests)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Install Linux system deps (Tauri)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Format check
+        run: cargo fmt --check --manifest-path src-tauri/Cargo.toml
+
+      - name: Clippy (deny warnings)
+        run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
+
+      - name: Tests
+        run: cargo test --manifest-path src-tauri/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
         with:
           node-version: 22
 
-      - name: Enable pnpm
-        run: corepack enable
+      - name: Setup pnpm (fixed v10)
+        run: npm install -g pnpm@10 && pnpm --version
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -73,5 +73,12 @@
     "vitest": "^4.0.17",
     "vue-eslint-parser": "^10.4.1",
     "vue-tsc": "^3.3.5"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@parcel/watcher",
+      "esbuild",
+      "vue-demi"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,10 @@ lockfileVersion: '9.0'
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
+  onlyBuiltDependencies:
+    - '@parcel/watcher'
+    - esbuild
+    - vue-demi
 
 importers:
 

--- a/src-tauri/src/gpu_settings.rs
+++ b/src-tauri/src/gpu_settings.rs
@@ -101,7 +101,10 @@ pub fn set_process_priority(priority: String) -> AppResult<()> {
         println!("✅ Process priority set to {}", priority);
     }
     #[cfg(not(target_os = "windows"))]
-    println!("⚠️ set_process_priority is Windows-only, ignoring");
+    {
+        let _ = &priority;
+        println!("⚠️ set_process_priority is Windows-only, ignoring");
+    }
     Ok(())
 }
 

--- a/src-tauri/src/save_commands.rs
+++ b/src-tauri/src/save_commands.rs
@@ -407,12 +407,19 @@ pub async fn handle_file(
         let visible_saves = get_visible_saves_set()?;
         let is_visible = visible_saves.contains(archive_name);
 
-        eprintln!("[handle_file] toggling visibility for '{}' (currently {})", archive_name, if is_visible { "visible" } else { "hidden" });
+        eprintln!(
+            "[handle_file] toggling visibility for '{}' (currently {})",
+            archive_name,
+            if is_visible { "visible" } else { "hidden" }
+        );
 
         if is_visible {
             let removed = remove_save_from_mainsave(archive_name)?;
             if !removed {
-                eprintln!("[handle_file] WARNING: '{}' not found in MAINSAVE SingleplayerSaves", archive_name);
+                eprintln!(
+                    "[handle_file] WARNING: '{}' not found in MAINSAVE SingleplayerSaves",
+                    archive_name
+                );
             }
         } else {
             add_save_to_mainsave(archive_name)?;

--- a/src-tauri/src/save_editor.rs
+++ b/src-tauri/src/save_editor.rs
@@ -236,8 +236,7 @@ fn process_player_data(save: &mut Save, json_data: &JsonValue) -> AppResult<()> 
     if let Some(player_inventory) = json_data["playerInventory"].as_object() {
         for steam_id in player_inventory.keys() {
             let trimmed_id = steam_id.trim().to_string();
-            if !trimmed_id.is_empty()
-                && !steam_ids_from_frontend.iter().any(|id| id == &trimmed_id)
+            if !trimmed_id.is_empty() && !steam_ids_from_frontend.iter().any(|id| id == &trimmed_id)
             {
                 steam_ids_from_frontend.push(trimmed_id);
             }

--- a/src/composables/__tests__/useArchiveSearchFilter.test.ts
+++ b/src/composables/__tests__/useArchiveSearchFilter.test.ts
@@ -169,7 +169,7 @@ describe("useArchiveList", () => {
     const { useArchiveList } = await import("../useArchiveSearchFilter");
     const archives = ref([createArchive({ id: 1 }), createArchive({ id: 2 })]);
     const { displayArchives } = useArchiveList(archives);
-    expect(displayArchives.value).toHaveLength(2);
+    await vi.waitFor(() => expect(displayArchives.value).toHaveLength(2));
   });
 
   it("filters by search query across name, level, difficulty, mode", async () => {
@@ -179,7 +179,7 @@ describe("useArchiveList", () => {
     const list = useArchiveList(archives);
     list.searchQuery.value = "alpha";
     await nextTick();
-    expect(list.displayArchives.value).toHaveLength(1);
+    await vi.waitFor(() => expect(list.displayArchives.value).toHaveLength(1));
     expect(list.displayArchives.value[0].id).toBe(1);
   });
 
@@ -193,7 +193,7 @@ describe("useArchiveList", () => {
     const list = useArchiveList(archives);
     list.selectedArchiveDifficulty.value = "hard";
     await nextTick();
-    expect(list.displayArchives.value).toHaveLength(1);
+    await vi.waitFor(() => expect(list.displayArchives.value).toHaveLength(1));
     expect(list.displayArchives.value[0].id).toBe(2);
   });
 
@@ -204,7 +204,7 @@ describe("useArchiveList", () => {
     const list = useArchiveList(archives);
     list.selectedVisibility.value = "hidden";
     await nextTick();
-    expect(list.displayArchives.value).toHaveLength(1);
+    await vi.waitFor(() => expect(list.displayArchives.value).toHaveLength(1));
     expect(list.displayArchives.value[0].isVisible).toBe(false);
   });
 
@@ -220,7 +220,7 @@ describe("useArchiveList", () => {
     list.selectedArchiveDifficulty.value = "easy";
     list.selectedVisibility.value = "visible";
     await nextTick();
-    expect(list.displayArchives.value).toHaveLength(1);
+    await vi.waitFor(() => expect(list.displayArchives.value).toHaveLength(1));
     expect(list.displayArchives.value[0].id).toBe(1);
   });
 
@@ -262,7 +262,7 @@ describe("useArchiveList", () => {
     expect(list.searchSuggestions.value).toHaveLength(0);
     list.searchQuery.value = "alpha";
     await nextTick();
-    expect(list.searchSuggestions.value).toHaveLength(1);
+    await vi.waitFor(() => expect(list.searchSuggestions.value).toHaveLength(1));
     expect(list.searchSuggestions.value[0].id).toBe(1);
   });
 });

--- a/src/composables/__tests__/useConfigResolver.test.ts
+++ b/src/composables/__tests__/useConfigResolver.test.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_CONFIG,
 } from "../useConfigResolver";
 import type { ArchiveConfig, UniformConfig, SmartRules, DifficultyLevel } from "../../types";
+import { FEATURES } from "@/config/features";
 
 const createArchiveConfig = (overrides: Partial<ArchiveConfig> = {}): ArchiveConfig => ({
   id: "test-1",
@@ -161,23 +162,43 @@ describe("resolve", () => {
   });
 
   describe("actual difficulty resolution", () => {
-    it("uses individual actual difficulty when set", () => {
-      const archive = createArchiveConfig({ actualDifficulty: "hard" as DifficultyLevel });
-      const result = resolve(archive, defaultUniform, defaultSmart);
-      expect(result.actualDifficulty).toBe("hard");
-      expect(result.source.actualDifficulty).toBe("individual");
-    });
+    // MERGE_DIFFICULTY 开启时（见 src/config/features.ts），实际难度镜像存档难度，
+    // individual/uniform 的 actualDifficulty 设置被特性有意合并
+    if (FEATURES.MERGE_DIFFICULTY) {
+      it("mirrors archive difficulty when merge enabled", () => {
+        const archive = createArchiveConfig({ difficulty: "hard" as DifficultyLevel });
+        const result = resolve(archive, defaultUniform, defaultSmart);
+        expect(result.actualDifficulty).toBe("hard");
+      });
 
-    it("uses uniform config actual difficulty", () => {
-      const archive = createArchiveConfig();
-      const uniform: UniformConfig = {
-        ...defaultUniform,
-        actualDifficulty: { enabled: true, value: "easy" },
-      };
-      const result = resolve(archive, uniform, defaultSmart);
-      expect(result.actualDifficulty).toBe("easy");
-      expect(result.source.actualDifficulty).toBe("uniform");
-    });
+      it("mirrors uniform difficulty when merge enabled", () => {
+        const archive = createArchiveConfig();
+        const uniform: UniformConfig = {
+          ...defaultUniform,
+          difficulty: { enabled: true, value: "easy" },
+        };
+        const result = resolve(archive, uniform, defaultSmart);
+        expect(result.actualDifficulty).toBe("easy");
+      });
+    } else {
+      it("uses individual actual difficulty when set", () => {
+        const archive = createArchiveConfig({ actualDifficulty: "hard" as DifficultyLevel });
+        const result = resolve(archive, defaultUniform, defaultSmart);
+        expect(result.actualDifficulty).toBe("hard");
+        expect(result.source.actualDifficulty).toBe("individual");
+      });
+
+      it("uses uniform config actual difficulty", () => {
+        const archive = createArchiveConfig();
+        const uniform: UniformConfig = {
+          ...defaultUniform,
+          actualDifficulty: { enabled: true, value: "easy" },
+        };
+        const result = resolve(archive, uniform, defaultSmart);
+        expect(result.actualDifficulty).toBe("easy");
+        expect(result.source.actualDifficulty).toBe("uniform");
+      });
+    }
   });
 
   describe("inventory resolution", () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import vue from "@vitejs/plugin-vue";
 import tailwindcss from "@tailwindcss/vite";
 import VueI18nVitePlugin from "@intlify/unplugin-vue-i18n/vite";
@@ -204,6 +204,18 @@ export default defineConfig(async ({ mode }) => {
       headers: {
         "Cache-Control": "public, max-age=31536000",
       },
+    },
+
+    // Vitest 配置：landing-page-react 是独立子项目（有自己的 alias 与依赖），
+    // 根 vitest 不应扫描它的测试
+    test: {
+      exclude: [
+        "**/node_modules/**",
+        "**/landing-page-react/**",
+        "**/dist/**",
+        "**/cypress/**",
+        "**/.{idea,git,cache,output,temp}/**",
+      ],
     },
   };
 });


### PR DESCRIPTION
## 改动内容

新增 `.github/workflows/ci.yml`，在 push/PR 时自动跑质量检查：

**Frontend job**（ubuntu）
- `pnpm lint` — ESLint 检查
- `pnpm test:unit` — Vitest 单测（含 fast-check 属性测试）

**Backend job**（ubuntu + Tauri 系统依赖）
- `cargo fmt --check` — 格式检查
- `cargo clippy --all-targets -- -D warnings` — 静态检查（warnings 即失败）
- `cargo test` — Rust 单测

## 说明
- 独立 job，不阻塞现有 release.yml 的发布流程
- 跑在 PR 和 master push 上，作为质量门禁
- 如果 clippy/test 有历史遗留问题导致红，PR 上能看到具体报错，我们再修